### PR TITLE
[FIX] Audio saving issues during Voice Design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ models/*
 *.prompt
 config.json
 Qwen/
+.hf_cache/
 
 # Jupyter
 .ipynb_checkpoints/


### PR DESCRIPTION
This PR fixes an issue with saving Voice Design output WAVs. While trying to do this on a Windows host, it wasn't able to save the generated output to the temp folder while running in a Docker container. These changes will harden the saving process which should make them more compatible across different runtime environments.

<img width="1191" height="825" alt="Screenshot 2026-02-01 111349" src="https://github.com/user-attachments/assets/ccbe77d4-6a4e-429c-af92-c5fe17bce08b" />

- Add `.hf_cache` to `.gitignore`
- Make audio file saving more robust by adding `tempfile` import, convert `tensor/PyTorch` audio to `numpy` before writing, ensure output directory exists, and fall back to a system temp file on save errors.
- Apply same `numpy` conversion and fallback handling when saving reference wavs. These changes prevent `sf.write` failures when given tensors and improve resilience against filesystem issues.