### PR TITLE
Omit config and copilot files from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,9 +116,7 @@ COPY ./modules /home/user/app/modules
 COPY ./wheel /home/user/app/wheel
 COPY ./tests /home/user/app/tests
 COPY ./docs /home/user/app/docs
-COPY ./config.json /home/user/app/config.json
 COPY ./voice_clone_studio.py /home/user/app/voice_clone_studio.py
-COPY ./.github/copilot-instructions.md /home/user/app/.github/copilot-instructions.md
 WORKDIR /home/user/app
 EXPOSE 7860
 CMD ["python3", "voice_clone_studio.py"]


### PR DESCRIPTION
There were issues copying files that were on the `.gitignore` list into the Docker container. This prevented the container from starting correctly. I've fixed this up in this PR, to account for the recent changes in the way configs are handled.

- Remove `COPY` directives for `config.json` and `./.github/copilot-instructions.md` so local configuration and internal instruction files are not baked into the image. In a previous commit `config.json` was removed, but the Dockerfile was not updated to reflect this, which prevented the container from starting.